### PR TITLE
Fix default import in TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ declare module 'launchdarkly-node-server-sdk-dynamodb' {
   /**
    * Create a feature flag store backed by DynamoDB.
    */
-  export function DynamoDBFeatureStore(
+  export default function DynamoDBFeatureStore(
     /**
      * The table name in DynamoDB. This table must already exist (see readme).
      */


### PR DESCRIPTION
The current TypeScript definitions throw type errors when the package is imported.

When imported as such:

```
import DynamoDBFeatureStore from 'launchdarkly-node-server-sdk-dynamodb'
```

The following type error is emitted from the compiler:

```
Cannot invoke an expression whose type lacks a call signature. Type 'typeof import("launchdarkly-node-server-sdk-dynamodb")' has no compatible call signatures.
```

This is because the default import has not been properly tagged, and so typescript thinks that DynamoDBFeatureStore is a named import and wants you to import like so:

```
import { DynamoDBFeatureStore } from 'launchdarkly-node-server-sdk-dynamodb'
```

But then at run time, this throws an error because that named import does not actually exist.

This PR correctly tags the function as a default export.

Fixes #10