### PR TITLE
remove typedoc dependency, update typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "jest-junit": "6.3.0",
     "launchdarkly-js-test-helpers": "^1.0.0",
     "launchdarkly-node-server-sdk": ">= 5.8.1",
-    "typescript": "3.0.1"
+    "typescript": "^3.8.3"
   },
   "jest": {
     "rootDir": ".",
@@ -34,7 +34,6 @@
   "dependencies": {
     "aws-sdk": "2.349.0",
     "node-cache": "4.2.0",
-    "typedoc": "0.15.0",
     "winston": "2.4.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
Typedoc is just for generating docs, so it should have been a dev dependency - but actually it doesn't need to be there either, because it's loaded automatically by our tools when we do a release.