### PR TITLE
move aws-sdk to peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,17 @@ This assumes that you have already installed the LaunchDarkly Node.js SDK.
 
         npm install launchdarkly-node-server-sdk-dynamodb --save
 
-3. Require the package:
+3. If your application does not already have its own dependency on the `aws-sdk` package, and if it will _not_ be running in AWS Lambda, add `aws-sdk` as well:
+
+        npm install aws-sdk --save
+
+    The `launchdarkly-node-server-sdk-dynamodb` package does not provide `aws-sdk` as a transitive dependency, because it is provided automatically by the Lambda runtime and this would unnecessarily increase the size of applications deployed in Lambda. Therefore, if you are not using Lambda you need to provide `aws-sdk` separately.
+
+4. Require the package:
 
         var DynamoDBFeatureStore = require('launchdarkly-node-server-sdk-dynamodb');
 
-4. When configuring your SDK client, add the DynamoDB feature store:
+5. When configuring your SDK client, add the DynamoDB feature store:
 
         var store = DynamoDBFeatureStore('YOUR TABLE NAME');
         var config = { featureStore: store };
@@ -39,12 +45,12 @@ This assumes that you have already installed the LaunchDarkly Node.js SDK.
 
         var store = DynamoDBFeatureStore('YOUR TABLE NAME', { dynamoDBClient: myDynamoDBClientInstance });
 
-5. If you are running a [LaunchDarkly Relay Proxy](https://github.com/launchdarkly/ld-relay) instance, or any other process that will prepopulate the DynamoDB table with feature flags from LaunchDarkly, you can use [daemon mode](https://github.com/launchdarkly/ld-relay#daemon-mode), so that the SDK retrieves flag data only from DynamoDB and does not communicate directly with LaunchDarkly. This is controlled by the SDK's `useLdd` option:
+6. If you are running a [LaunchDarkly Relay Proxy](https://github.com/launchdarkly/ld-relay) instance, or any other process that will prepopulate the DynamoDB table with feature flags from LaunchDarkly, you can use [daemon mode](https://github.com/launchdarkly/ld-relay#daemon-mode), so that the SDK retrieves flag data only from DynamoDB and does not communicate directly with LaunchDarkly. This is controlled by the SDK's `useLdd` option:
 
         var config = { featureStore: store, useLdd: true };
         var client = LaunchDarkly.init('YOUR SDK KEY', config);
 
-6. If the same DynamoDB table is being shared by SDK clients for different LaunchDarkly environments, set the `prefix` option to a different short string for each one to keep the keys from colliding:
+7. If the same DynamoDB table is being shared by SDK clients for different LaunchDarkly environments, set the `prefix` option to a different short string for each one to keep the keys from colliding:
 
         var store = DynamoDBFeatureStore('YOUR TABLE NAME', { prefix: 'env1' });
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
+    "aws-sdk": "^2.349.0",
     "babel-jest": "24.7.1",
     "eslint": "5.8.0",
     "eslint-formatter-pretty": "1.3.0",
@@ -32,11 +33,11 @@
     "transformIgnorePatterns": []
   },
   "dependencies": {
-    "aws-sdk": "2.349.0",
     "node-cache": "4.2.0",
     "winston": "2.4.1"
   },
   "peerDependencies": {
+    "aws-sdk": "^2.349.0",
     "launchdarkly-node-server-sdk": ">= 5.8.1"
   },
   "engines": {


### PR DESCRIPTION
When Node code runs in Lambda, the AWS SDK package is provided automatically, so we shouldn't require people to have it in their own node_modules (https://github.com/launchdarkly/node-server-sdk-dynamodb/issues/12). The solution is to make it a peer dependency and tell people that they must add it themselves if they're not running in Lambda.

That's technically a breaking change because any non-Lambda code that currently uses this package, but does not have its own dependency on AWS, will need to add that dependency before it'll work with this change. Therefore the next release would be 2.0.0.