### PR TITLE
Only Require DynamoDB and Not Entire AWS SDK

### DIFF
--- a/dynamodb_feature_store.js
+++ b/dynamodb_feature_store.js
@@ -1,4 +1,4 @@
-var AWS = require('aws-sdk');
+var DynamoDB = require('aws-sdk/clients/dynamodb');
 var winston = require('winston');
 
 var helpers = require('./dynamodb_helpers');
@@ -24,7 +24,7 @@ function dynamoDBFeatureStoreInternal(tableName, options) {
       ]
     })
   );
-  var dynamoDBClient = options.dynamoDBClient || new AWS.DynamoDB.DocumentClient(options.clientOptions);
+  var dynamoDBClient = options.dynamoDBClient || new DynamoDB.DocumentClient(options.clientOptions);
   var prefix = options.prefix || '';
 
   var store = {};


### PR DESCRIPTION
At my company we use this project with Lambda@Edge, requiring the AWS-SDK, rather than DynamoDB individually increases cold start time, making the lambda less practical to use.

We are seeing a significant reduction in cold start time with this patch.

(Appreciate this is out of the blue, and is more of a suggestion rather than a ready to go merge request, but please let me know what you think :) )
