### PR TITLE
(3.0) update minimum SDK version and Node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,37 +1,58 @@
-version: 2
+version: 2.1
 
 workflows:
-  version: 2
-  test:
+  build-and-test-all:
     jobs:
-      - oldest-long-term-support-release
-      - current-release
-
-node-template: &node-template
-  steps:
-    - checkout
-    - run: echo "Node version:" `node --version`
-    - run: npm install
-    - run: npm run lint
-    - run:
-        command: npm test
-        environment:
-          JEST_JUNIT_OUTPUT: "reports/junit/js-test-results.xml"
-    - store_test_results:
-        path: reports/junit
-    - run: npm run check-typescript
-    - store_artifacts:
-        path: reports/junit
+      # CircleCI's current generation of Node images, cimg/node, allow you to leave the
+      # patch version unpinned, but require you to specify the minor version. The one
+      # exception is cimg/node:current, which will always give us the latest release in
+      # the latest major version-- and the latest major version is where it's most likely
+      # that there would be a new minor version, anyway.
+      - build-test-linux:
+          name: latest Node version
+          docker-image: cimg/node:current
+          run-lint: true
+      - build-test-linux:
+          name: Node 16.3
+          docker-image: cimg/node:16.3
+      - build-test-linux:
+          name: Node 15.14
+          docker-image: cimg/node:15.14
+      - build-test-linux:
+          name: Node 14.17
+          docker-image: cimg/node:14.17
+      - build-test-linux:
+          name: Node 13.14
+          docker-image: cimg/node:13.14
+      - build-test-linux:
+          name: Node 12.22
+          docker-image: cimg/node:12.22
 
 jobs:
-  oldest-long-term-support-release:
-    <<: *node-template
+  build-test-linux:
+    parameters:
+      run-lint:
+        type: boolean
+        default: false
+      docker-image:
+        type: string
     docker:
-      - image: circleci/node:6
+      - image: <<parameters.docker-image>>
       - image: amazon/dynamodb-local
-
-  current-release:
-    <<: *node-template
-    docker:
-      - image: circleci/node:latest
-      - image: amazon/dynamodb-local
+    steps:
+      - checkout
+      - run: echo "Node version:" `node --version`
+      - run: npm install
+      - run:
+          command: npm test
+          environment:
+            JEST_JUNIT_OUTPUT: "reports/junit/js-test-results.xml"
+      - run: npm run check-typescript
+      - when:
+          condition: <<parameters.run-lint>>
+          steps:
+            - run: npm run lint
+      - store_test_results:
+          path: reports/junit
+      - store_artifacts:
+          path: reports/junit

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 node_modules/
+test-types.js

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing to this library
+
+The source code for this library is [here](https://github.com/launchdarkly/node-server-sdk-dynamodb). We encourage pull-requests and other contributions from the community. Since this library is meant to be used in conjunction with the LaunchDarkly Server-Side Node.js SDK, you may want to look at the [SDK source code](https://github.com/launchdarkly/dotnet-server-sdk) and our [SDK contributor's guide](http://docs.launchdarkly.com/docs/sdk-contributors-guide).
+
+## Submitting bug reports and feature requests
+ 
+The LaunchDarkly SDK team monitors the [issue tracker](https://github.com/launchdarkly/node-server-sdk-dynamodb/issues) in this repository. Bug reports and feature requests specific to this project should be filed in the issue tracker. The SDK team will respond to all newly filed issues within two business days.
+ 
+## Submitting pull requests
+ 
+We encourage pull requests and other contributions from the community. Before submitting pull requests, ensure that all temporary or unintended code is removed. Don't worry about adding reviewers to the pull request; the LaunchDarkly SDK team will add themselves. The SDK team will acknowledge all pull requests within two business days.
+ 
+## Build instructions
+ 
+### Prerequisites
+
+The project uses `npm`, which is bundled in all supported versions of Node. It should be built against the lowest compatible version, Node 12.
+
+### Setup
+
+To install project dependencies, from the project root directory:
+
+```
+npm install
+```
+
+### Testing
+
+To run all unit tests:
+
+```
+npm test
+```
+
+The tests expect you to have DynamoDB running locally on the default port, 6379. One way to do this is with Docker:
+
+```bash
+docker run -p 8000:8000 amazon/dynamodb-local
+```
+
+To verify that the TypeScript declarations compile correctly (this involves compiling the file `test-types.ts`, so if you have changed any types or interfaces, you will want to update that code):
+
+```
+npm run check-typescript
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to this library
 
-The source code for this library is [here](https://github.com/launchdarkly/node-server-sdk-dynamodb). We encourage pull-requests and other contributions from the community. Since this library is meant to be used in conjunction with the LaunchDarkly Server-Side Node.js SDK, you may want to look at the [SDK source code](https://github.com/launchdarkly/dotnet-server-sdk) and our [SDK contributor's guide](http://docs.launchdarkly.com/docs/sdk-contributors-guide).
+The source code for this library is [here](https://github.com/launchdarkly/node-server-sdk-dynamodb). We encourage pull-requests and other contributions from the community. Since this library is meant to be used in conjunction with the LaunchDarkly Server-Side Node.js SDK, you may want to look at the [SDK source code](https://github.com/launchdarkly/node-server-sdk) and our [SDK contributor's guide](http://docs.launchdarkly.com/docs/sdk-contributors-guide).
 
 ## Submitting bug reports and feature requests
  

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 This library provides a DynamoDB-backed persistence mechanism (feature store) for the [LaunchDarkly Node.js SDK](https://github.com/launchdarkly/node-server-sdk), replacing the default in-memory feature store. It uses the AWS SDK for Node.js.
 
-The minimum version of the LaunchDarkly Node.js SDK for use with this library is 5.8.1.
+The minimum version of the LaunchDarkly Node.js SDK for use with this library is 6.0.0.
 
-For more information, see also: [Using a persistent feature store](https://docs.launchdarkly.com/v2.0/docs/using-a-persistent-feature-store).
+For more information, see the [SDK features guide](https://docs.launchdarkly.com/sdk/features/database-integrations).
 
 TypeScript API documentation is [here](https://launchdarkly.github.io/node-server-sdk-dynamodb).
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "jest": "24.7.1",
     "jest-junit": "6.3.0",
     "launchdarkly-js-test-helpers": "^1.0.0",
-    "launchdarkly-node-server-sdk": ">= 5.8.1",
+    "launchdarkly-node-server-sdk": "^6.0.0-alpha.1",
     "typescript": "^3.8.3"
   },
   "jest": {
@@ -38,10 +38,10 @@
   },
   "peerDependencies": {
     "aws-sdk": "^2.349.0",
-    "launchdarkly-node-server-sdk": ">= 5.8.1"
+    "launchdarkly-node-server-sdk": "^6.0.0-alpha.1"
   },
   "engines": {
-    "node": ">= 0.8.x"
+    "node": ">= 12.0"
   },
   "bugs": {
     "url": "https://github.com/launchdarkly/node-server-sdk-dynamodb/issues"


### PR DESCRIPTION
The upcoming 6.0.0 SDK will raise the minimum Node version to 12.